### PR TITLE
Dynamicnac

### DIFF
--- a/mesh/apps/consumer.cpp
+++ b/mesh/apps/consumer.cpp
@@ -1,4 +1,4 @@
-/* consumer.cpp (KDK宛名自動同期版) */
+/* consumer.cpp (KDKネットワーク取得対応版) */
 #include <ndn-cxx/face.hpp>
 #include <ndn-cxx/security/key-chain.hpp>
 #include <ndn-cxx/security/validator-config.hpp>
@@ -21,30 +21,104 @@ public:
   Consumer()
     : m_face(nullptr, m_keyChain)
     , m_validator(m_face)
-    // Decryptorの初期化はコンストラクタ本体で行う
   {
     // 1. 環境設定
     const char* prefixEnv = std::getenv("NDN_DATA_PREFIX");
     m_dataPrefix = prefixEnv ? Name(prefixEnv) : Name("/ndn/test/data");
 
-    // バリデータ設定
+    // バリデータ設定 (テスト用: 全許可)
     m_validator.load(R"CONF(trust-anchor { type any })CONF", "fake-config");
+  }
 
-    // 2. KDKの自動検知とロード
+  void run()
+  {
+    // 2. KDKの検索 (ローカル -> なければネットワーク)
     std::string kdkPath = findKeyFile("/data/nac-data", "kdk_");
-    if (kdkPath.empty()) {
-        std::cerr << "WARN: No KDK file found. Decryption might fail." << std::endl;
-        return;
+
+    if (!kdkPath.empty()) {
+        std::cout << "Found local KDK: " << kdkPath << std::endl;
+        auto kdkData = ndn::io::load<Data>(kdkPath);
+        if (kdkData) {
+            initializeDecryptor(kdkData);
+            sendContentInterest(); // 準備完了なのでコンテンツを取りに行く
+        } else {
+            std::cerr << "Failed to load local KDK. Trying network..." << std::endl;
+            fetchKdk();
+        }
+    } else {
+        std::cout << "No local KDK found. Fetching from KDK Server..." << std::endl;
+        fetchKdk();
     }
 
-    m_kdkData = ndn::io::load<Data>(kdkPath);
-    if (!m_kdkData) {
-        throw std::runtime_error("Failed to parse KDK data");
-    }
-    std::cout << "Loaded KDK: " << m_kdkData->getName() << std::endl;
+    m_face.processEvents();
+  }
 
-    // 3. KDKから「正しいIdentity」を抽出する
-    // KDK名: /<KEK-Prefix>/KDK/<ID>/ENCRYPTED-BY/<IdentityName>/KEY/<KeyID>
+private:
+  // KDKをネットワークから取得する
+  void fetchKdk() {
+      // KDKの名前は通常 /<DataPrefix>/NAC/KDK/<KEK-ID>/... となる
+      // 正確な名前がわからないため、Prefix探索を行う
+      Name kdkQuery = m_dataPrefix;
+      kdkQuery.append("NAC").append("KDK");
+
+      Interest interest(kdkQuery);
+      interest.setCanBePrefix(true); // 具体的なIDが不明なためPrefixで検索
+      interest.setMustBeFresh(true);
+
+      std::cout << "=== Fetching KDK: " << interest.getName() << " ===" << std::endl;
+
+      m_face.expressInterest(interest,
+          std::bind(&Consumer::onKdkData, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&Consumer::onNack, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&Consumer::onTimeout, this, std::placeholders::_1)
+      );
+  }
+
+  // KDK受信時の処理
+  void onKdkData(const Interest&, const Data& data) {
+      std::cout << "Received KDK Data: " << data.getName() << std::endl;
+      // メモリ上のDataをshared_ptrとしてコピー
+      auto kdkData = std::make_shared<Data>(data);
+
+      try {
+          initializeDecryptor(kdkData);
+          // KDKの準備ができたら、本来のコンテンツを取りに行く
+          sendContentInterest();
+      } catch (const std::exception& e) {
+          std::cerr << "Failed to initialize Decryptor with fetched KDK: " << e.what() << std::endl;
+          exit(1);
+      }
+  }
+
+  // Decryptorの初期化 (ローカル/ネットワーク共通)
+  void initializeDecryptor(std::shared_ptr<Data> kdkData) {
+    m_kdkData = kdkData;
+
+    // Node3のIdentityを特定する (setup.shで生成されたもの)
+    // ※今回はハードコードだが、汎用化するなら環境変数等で自身のIDを渡す
+    Name identityName("/ndn/waseda/labA/ndn-node3");
+
+    ndn::security::pib::Identity myIdentity;
+    try {
+        myIdentity = m_keyChain.getPib().getIdentity(identityName);
+    } catch (const std::exception&) {
+        std::cout << "WARN: Full identity " << identityName << " not found. Using default." << std::endl;
+        myIdentity = m_keyChain.getPib().getDefaultIdentity();
+    }
+
+    std::cout << "Initializing Decryptor with Identity: " << myIdentity.getName() << std::endl;
+
+    // Decryptor作成
+    m_decryptor = std::make_unique<Decryptor>(
+        myIdentity.getDefaultKey(),
+        m_validator,
+        m_keyChain,
+        m_face
+    );
+
+    // KDK配信登録 (Decryptorが内部でKDKを要求したときに答えるため)
+    // 名前構造: .../ENCRYPTED-BY/<KeyLocator>
+    // ENCRYPTED-BY コンポーネントを探す
     Name kdkName = m_kdkData->getName();
     ssize_t encryptedByIdx = -1;
     for (size_t i = 0; i < kdkName.size(); ++i) {
@@ -54,83 +128,24 @@ public:
         }
     }
 
-    if (encryptedByIdx == -1) {
-        throw std::runtime_error("Invalid KDK name format (missing ENCRYPTED-BY)");
+    if (encryptedByIdx != -1) {
+        Name prefixToServe = m_kdkData->getName().getPrefix(encryptedByIdx + 1);
+        std::cout << "Serving KDK to Decryptor at: " << prefixToServe << std::endl;
+
+        m_kdkHandle = m_face.setInterestFilter(
+            prefixToServe,
+            [this](const InterestFilter&, const Interest& interest) {
+                if (interest.matchesData(*m_kdkData)) {
+                     m_face.put(*m_kdkData);
+                }
+            },
+            [](const Name&, const std::string& msg) { std::cerr << "KDK Reg Failed: " << msg << std::endl; }
+        );
     }
-
-    // ENCRYPTED-BY の後ろから KEY の前までが Identity Name
-    // 例: .../ENCRYPTED-BY /ndn/waseda/labA/ndn-node3 /KEY/...
-    //                       ^ start                     ^ end
-    // Name::getPrefix などを駆使して抽出もできるが、
-    // ここではKeyChainから「KDK名に含まれるIdentity」を探す
-
-    ndn::security::pib::Identity identity;
-    bool found = false;
-    for (const auto& id : m_keyChain.getPib().getIdentities()) {
-        // ID名が KDK名の一部に含まれているか確認
-        // (ID名が /ndn/waseda/labA/ndn-node3 なら、KDK名の中にその並びがあるはず)
-        // 部分一致判定は面倒なので、ここでは簡易的に「デフォルトID」か「KDK名から推測」する
-
-        // 確実な方法: KDKの名前構造からIdentityを切り出す
-        // ENCRYPTED-BY(idx) + 1  から  KEY(idx_key) - 1 まで
-        // しかしKEYの位置を探すのも手間なので、
-        // 「デフォルトID」と「短いID(ndn-node3)」の両方を試す戦略をとる
-
-        try {
-             // とりあえず setup.sh で作ったフルネームIdentityを持っているはず
-             Name fullName("/ndn/waseda/labA/ndn-node3"); // 環境に合わせて修正が必要だが...
-             // 自動化のため、KDK名のサフィックス(KEYの一つ前)を見る手もあるが、
-             // 一番安全なのは「KDKが要求している名前で待機すること」
-        } catch (...) {}
-    }
-
-    // ★最も確実な修正★
-    // Decryptorに渡す「自分の鍵」を、KeyChainのデフォルトではなく、
-    // KDKファイルと整合するものを強制的に探して設定する。
-
-    // Node3の正しいフルネームIdentity (setup.shで生成されたもの)
-    // ※汎用化のため、topology.txtや環境変数から取るべきだが、今回はハードコードで解決する
-    Name identityName("/ndn/waseda/labA/ndn-node3");
-
-    ndn::security::pib::Identity myIdentity;
-    try {
-        myIdentity = m_keyChain.getPib().getIdentity(identityName);
-    } catch (const std::exception&) {
-        // フルネームがない場合、仕方ないのでデフォルトを使う
-        std::cout << "WARN: Full identity " << identityName << " not found. Using default." << std::endl;
-        myIdentity = m_keyChain.getPib().getDefaultIdentity();
-    }
-
-    std::cout << "Using Identity for Decryptor: " << myIdentity.getName() << std::endl;
-
-    // 4. Decryptorの初期化 (遅延初期化)
-    m_decryptor = std::make_unique<Decryptor>(
-        myIdentity.getDefaultKey(), // KDKに適合する鍵を渡す
-        m_validator,
-        m_keyChain,
-        m_face
-    );
-
-    // 5. KDK配信登録
-    // Decryptorが投げるInterest (Short Name かもしれないし Long かもしれない) を
-    // 確実に拾うために、KDKの完全一致ではなく、前方一致(Prefix)で登録する
-    // .../ENCRYPTED-BY まで登録しておけば、後ろが何であれ拾える
-    Name prefixToServe = m_kdkData->getName().getPrefix(encryptedByIdx + 1); // .../ENCRYPTED-BY
-    std::cout << "Serving KDK at prefix: " << prefixToServe << std::endl;
-
-    m_kdkHandle = m_face.setInterestFilter(
-        prefixToServe,
-        [this](const InterestFilter&, const Interest& interest) {
-            // Decryptorからの要求であれば返す
-            // 名前が完全一致しなくても、KDKを返してみる (Decryptorが判断する)
-             m_face.put(*m_kdkData);
-        },
-        [](const Name&, const std::string& msg) { std::cerr << "KDK Reg Failed: " << msg << std::endl; }
-    );
   }
 
-  void run()
-  {
+  // コンテンツ取得リクエスト
+  void sendContentInterest() {
     Interest interest(m_dataPrefix);
     interest.setCanBePrefix(true);
     interest.setMustBeFresh(true);
@@ -141,13 +156,15 @@ public:
       std::bind(&Consumer::onNack, this, std::placeholders::_1, std::placeholders::_2),
       std::bind(&Consumer::onTimeout, this, std::placeholders::_1)
     );
-
-    m_face.processEvents();
   }
 
-private:
   void onData(const Interest&, const Data& data) {
-    std::cout << "Received Data. Decrypting..." << std::endl;
+    std::cout << "Received Content Data. Decrypting..." << std::endl;
+
+    if (!m_decryptor) {
+        std::cerr << "FATAL: Decryptor not initialized!" << std::endl;
+        exit(1);
+    }
 
     Block contentBlock = data.getContent();
     contentBlock.parse();
@@ -167,20 +184,20 @@ private:
     );
   }
 
-  void onNack(const Interest&, const lp::Nack& nack) const {
-    std::cerr << "Nack: " << nack.getReason() << std::endl;
+  void onNack(const Interest& interest, const lp::Nack& nack) const {
+    std::cerr << "Nack for " << interest.getName() << ": " << nack.getReason() << std::endl;
     exit(1);
   }
 
-  void onTimeout(const Interest&) const {
-    std::cerr << "Timeout" << std::endl;
+  void onTimeout(const Interest& interest) const {
+    std::cerr << "Timeout for " << interest.getName() << std::endl;
     exit(1);
   }
 
   KeyChain m_keyChain;
   Face m_face;
   ValidatorConfig m_validator;
-  std::unique_ptr<Decryptor> m_decryptor; // ポインタに変更
+  std::unique_ptr<Decryptor> m_decryptor;
   std::shared_ptr<Data> m_kdkData;
   ScopedRegisteredPrefixHandle m_kdkHandle;
   Name m_dataPrefix;

--- a/mesh/apps/kdk-server.cpp
+++ b/mesh/apps/kdk-server.cpp
@@ -1,0 +1,105 @@
+#include <ndn-cxx/face.hpp>
+#include <ndn-cxx/security/key-chain.hpp>
+#include <ndn-cxx/util/io.hpp>
+#include <iostream>
+#include <filesystem>
+#include <map>
+
+namespace fs = std::filesystem;
+
+namespace ndn::nac::server {
+
+class KdkServer
+{
+public:
+  KdkServer()
+    : m_face(nullptr, m_keyChain)
+  {
+    loadDataFiles("/data/nac-data");
+  }
+
+  void run()
+  {
+    if (m_store.empty()) {
+      std::cerr << "WARN: No data loaded. Server is idle." << std::endl;
+    } else {
+      std::cout << "KDK Server running. Serving " << m_store.size() << " data packets." << std::endl;
+    }
+    m_face.processEvents();
+  }
+
+private:
+  void loadDataFiles(const std::string& pathStr)
+  {
+    fs::path dir(pathStr);
+    if (!fs::exists(dir) || !fs::is_directory(dir)) {
+      std::cerr << "Error: Directory not found: " << pathStr << std::endl;
+      return;
+    }
+
+    for (const auto& entry : fs::directory_iterator(dir)) {
+      if (entry.path().extension() == ".data") {
+        try {
+          auto data = ndn::io::load<Data>(entry.path().string());
+          if (data) {
+            storeData(data);
+          }
+        }
+        catch (const std::exception& e) {
+          std::cerr << "Failed to load " << entry.path() << ": " << e.what() << std::endl;
+        }
+      }
+    }
+  }
+
+  void storeData(std::shared_ptr<Data> data)
+  {
+    Name name = data->getName();
+    m_store[name] = data;
+
+    std::cout << "Loaded: " << name << std::endl;
+
+    // NACのKDKやKEKは、名前が特殊であるため、
+    // ここでは単純化のために「Dataの完全名」でInterestFilterを設定するのではなく、
+    // 「AccessManagerのPrefix」や「KEKのPrefix」を広報するのが正しい。
+    // しかし、動的にPrefixを決定するのが難しいため、
+    // 「Dataの名前そのもの(Full Name without implicit digest)」に対してFilterを設定するアプローチをとる。
+    // ※あるいは、AMのPrefix ("/ndn/AM") が固定なら、コンストラクタで1回だけ登録する方が効率的。
+
+    // 今回は確実にHitさせるため、各データの名前で登録する (データ数が少ない実験環境ならこれでOK)
+    m_face.setInterestFilter(name,
+      [this, data](const InterestFilter&, const Interest& interest) {
+        // InterestがCanBePrefixを持っている場合などに対応
+        if (data->getName().isPrefixOf(interest.getName()) ||
+            interest.matchesData(*data)) {
+          std::cout << "Serving: " << data->getName() << std::endl;
+          m_face.put(*data);
+        }
+      },
+      [](const Name& prefix, const std::string& msg) {
+        std::cerr << "Register failed for " << prefix << ": " << msg << std::endl;
+      }
+    );
+  }
+
+private:
+  KeyChain m_keyChain;
+  Face m_face;
+  // メモリ上にDataを保持する簡易ストア
+  std::map<Name, std::shared_ptr<Data>> m_store;
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  try {
+    ndn::nac::server::KdkServer server;
+    server.run();
+  }
+  catch (const std::exception& e) {
+    std::cerr << "FATAL: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/mesh/create.sh
+++ b/mesh/create.sh
@@ -47,8 +47,19 @@ for pod in $PODS; do
     # kubectl exec で内部コマンドを一気に流し込む
     # nohup & を使うことで、スクリプト終了後もプロセスを維持
     kubectl exec $pod -- /bin/bash -c "
-        # 証明書セットアップ
-        ndnsec key-gen /$NODE_NAME | ndnsec cert-install - || true
+        #init-containerで証明書は既にimportされていることを確認
+        EXISTING_ID=\$(ndnsec list 2>/dev/null | grep -o \"/.*\" | head -n 1)
+        if [ -n \"\$EXISTING_ID\" ]; then
+             echo \"Found identity prepared by InitContainer: \$EXISTING_ID\"
+             ndnsec set-default \$EXISTING_ID
+        else
+             echo \"Error: No identity found in /data/.ndn (HOME=\$HOME).\"
+             echo \"Debug: Listing /data/.ndn content:\"
+             ls -R /data/.ndn
+             echo \"Debug: Output of ndnsec list:\"
+             ndnsec list
+             exit 1
+        fi
 
         # NFD起動 (二重起動防止)
         if ! pgrep nfd > /dev/null; then
@@ -82,6 +93,29 @@ for pod in $PODS; do
                 done
             done
         ) > /face-create.log 2>&1 &
+
+        if ls /data/nac-data/kdk_*.data 1> /dev/null 2>&1; then
+            echo \"=== AM Node Detected (KDK files found) ===\"
+
+            # すでに起動していない場合のみ実行
+            if ! pgrep kdk-server > /dev/null; then
+                echo \"Compiling KDK Server...\"
+                # pkg-configの実行結果をコンテナ内で展開するために \$() を使用
+                g++ -o /usr/local/bin/kdk-server /usr/src/app/kdk-server.cpp \
+                    \$(pkg-config --cflags --libs libndn-cxx) -std=c++17
+
+                if [ \$? -eq 0 ]; then
+                    echo \"Starting KDK Server in background...\"
+                    nohup /usr/local/bin/kdk-server > /data/kdk-server.log 2>&1 &
+                else
+                    echo \"Error: Failed to compile KDK Server\"
+                fi
+            else
+                 echo \"KDK Server is already running.\"
+            fi
+        else
+            echo \"=== Consumer/Producer Node (No KDK files) ===\"
+        fi
     "
 done
 

--- a/mesh/manifest/apps/consumer.cpp
+++ b/mesh/manifest/apps/consumer.cpp
@@ -1,4 +1,4 @@
-/* consumer.cpp (KDK宛名自動同期版) */
+/* consumer.cpp (KDKネットワーク取得対応版) */
 #include <ndn-cxx/face.hpp>
 #include <ndn-cxx/security/key-chain.hpp>
 #include <ndn-cxx/security/validator-config.hpp>
@@ -21,30 +21,104 @@ public:
   Consumer()
     : m_face(nullptr, m_keyChain)
     , m_validator(m_face)
-    // Decryptorの初期化はコンストラクタ本体で行う
   {
     // 1. 環境設定
     const char* prefixEnv = std::getenv("NDN_DATA_PREFIX");
     m_dataPrefix = prefixEnv ? Name(prefixEnv) : Name("/ndn/test/data");
 
-    // バリデータ設定
+    // バリデータ設定 (テスト用: 全許可)
     m_validator.load(R"CONF(trust-anchor { type any })CONF", "fake-config");
+  }
 
-    // 2. KDKの自動検知とロード
+  void run()
+  {
+    // 2. KDKの検索 (ローカル -> なければネットワーク)
     std::string kdkPath = findKeyFile("/data/nac-data", "kdk_");
-    if (kdkPath.empty()) {
-        std::cerr << "WARN: No KDK file found. Decryption might fail." << std::endl;
-        return;
+
+    if (!kdkPath.empty()) {
+        std::cout << "Found local KDK: " << kdkPath << std::endl;
+        auto kdkData = ndn::io::load<Data>(kdkPath);
+        if (kdkData) {
+            initializeDecryptor(kdkData);
+            sendContentInterest(); // 準備完了なのでコンテンツを取りに行く
+        } else {
+            std::cerr << "Failed to load local KDK. Trying network..." << std::endl;
+            fetchKdk();
+        }
+    } else {
+        std::cout << "No local KDK found. Fetching from KDK Server..." << std::endl;
+        fetchKdk();
     }
 
-    m_kdkData = ndn::io::load<Data>(kdkPath);
-    if (!m_kdkData) {
-        throw std::runtime_error("Failed to parse KDK data");
-    }
-    std::cout << "Loaded KDK: " << m_kdkData->getName() << std::endl;
+    m_face.processEvents();
+  }
 
-    // 3. KDKから「正しいIdentity」を抽出する
-    // KDK名: /<KEK-Prefix>/KDK/<ID>/ENCRYPTED-BY/<IdentityName>/KEY/<KeyID>
+private:
+  // KDKをネットワークから取得する
+  void fetchKdk() {
+      // KDKの名前は通常 /<DataPrefix>/NAC/KDK/<KEK-ID>/... となる
+      // 正確な名前がわからないため、Prefix探索を行う
+      Name kdkQuery = m_dataPrefix;
+      kdkQuery.append("NAC").append("KDK");
+
+      Interest interest(kdkQuery);
+      interest.setCanBePrefix(true); // 具体的なIDが不明なためPrefixで検索
+      interest.setMustBeFresh(true);
+
+      std::cout << "=== Fetching KDK: " << interest.getName() << " ===" << std::endl;
+
+      m_face.expressInterest(interest,
+          std::bind(&Consumer::onKdkData, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&Consumer::onNack, this, std::placeholders::_1, std::placeholders::_2),
+          std::bind(&Consumer::onTimeout, this, std::placeholders::_1)
+      );
+  }
+
+  // KDK受信時の処理
+  void onKdkData(const Interest&, const Data& data) {
+      std::cout << "Received KDK Data: " << data.getName() << std::endl;
+      // メモリ上のDataをshared_ptrとしてコピー
+      auto kdkData = std::make_shared<Data>(data);
+
+      try {
+          initializeDecryptor(kdkData);
+          // KDKの準備ができたら、本来のコンテンツを取りに行く
+          sendContentInterest();
+      } catch (const std::exception& e) {
+          std::cerr << "Failed to initialize Decryptor with fetched KDK: " << e.what() << std::endl;
+          exit(1);
+      }
+  }
+
+  // Decryptorの初期化 (ローカル/ネットワーク共通)
+  void initializeDecryptor(std::shared_ptr<Data> kdkData) {
+    m_kdkData = kdkData;
+
+    // Node3のIdentityを特定する (setup.shで生成されたもの)
+    // ※今回はハードコードだが、汎用化するなら環境変数等で自身のIDを渡す
+    Name identityName("/ndn/waseda/labA/ndn-node3");
+
+    ndn::security::pib::Identity myIdentity;
+    try {
+        myIdentity = m_keyChain.getPib().getIdentity(identityName);
+    } catch (const std::exception&) {
+        std::cout << "WARN: Full identity " << identityName << " not found. Using default." << std::endl;
+        myIdentity = m_keyChain.getPib().getDefaultIdentity();
+    }
+
+    std::cout << "Initializing Decryptor with Identity: " << myIdentity.getName() << std::endl;
+
+    // Decryptor作成
+    m_decryptor = std::make_unique<Decryptor>(
+        myIdentity.getDefaultKey(),
+        m_validator,
+        m_keyChain,
+        m_face
+    );
+
+    // KDK配信登録 (Decryptorが内部でKDKを要求したときに答えるため)
+    // 名前構造: .../ENCRYPTED-BY/<KeyLocator>
+    // ENCRYPTED-BY コンポーネントを探す
     Name kdkName = m_kdkData->getName();
     ssize_t encryptedByIdx = -1;
     for (size_t i = 0; i < kdkName.size(); ++i) {
@@ -54,83 +128,24 @@ public:
         }
     }
 
-    if (encryptedByIdx == -1) {
-        throw std::runtime_error("Invalid KDK name format (missing ENCRYPTED-BY)");
+    if (encryptedByIdx != -1) {
+        Name prefixToServe = m_kdkData->getName().getPrefix(encryptedByIdx + 1);
+        std::cout << "Serving KDK to Decryptor at: " << prefixToServe << std::endl;
+
+        m_kdkHandle = m_face.setInterestFilter(
+            prefixToServe,
+            [this](const InterestFilter&, const Interest& interest) {
+                if (interest.matchesData(*m_kdkData)) {
+                     m_face.put(*m_kdkData);
+                }
+            },
+            [](const Name&, const std::string& msg) { std::cerr << "KDK Reg Failed: " << msg << std::endl; }
+        );
     }
-
-    // ENCRYPTED-BY の後ろから KEY の前までが Identity Name
-    // 例: .../ENCRYPTED-BY /ndn/waseda/labA/ndn-node3 /KEY/...
-    //                       ^ start                     ^ end
-    // Name::getPrefix などを駆使して抽出もできるが、
-    // ここではKeyChainから「KDK名に含まれるIdentity」を探す
-
-    ndn::security::pib::Identity identity;
-    bool found = false;
-    for (const auto& id : m_keyChain.getPib().getIdentities()) {
-        // ID名が KDK名の一部に含まれているか確認
-        // (ID名が /ndn/waseda/labA/ndn-node3 なら、KDK名の中にその並びがあるはず)
-        // 部分一致判定は面倒なので、ここでは簡易的に「デフォルトID」か「KDK名から推測」する
-
-        // 確実な方法: KDKの名前構造からIdentityを切り出す
-        // ENCRYPTED-BY(idx) + 1  から  KEY(idx_key) - 1 まで
-        // しかしKEYの位置を探すのも手間なので、
-        // 「デフォルトID」と「短いID(ndn-node3)」の両方を試す戦略をとる
-
-        try {
-             // とりあえず setup.sh で作ったフルネームIdentityを持っているはず
-             Name fullName("/ndn/waseda/labA/ndn-node3"); // 環境に合わせて修正が必要だが...
-             // 自動化のため、KDK名のサフィックス(KEYの一つ前)を見る手もあるが、
-             // 一番安全なのは「KDKが要求している名前で待機すること」
-        } catch (...) {}
-    }
-
-    // ★最も確実な修正★
-    // Decryptorに渡す「自分の鍵」を、KeyChainのデフォルトではなく、
-    // KDKファイルと整合するものを強制的に探して設定する。
-
-    // Node3の正しいフルネームIdentity (setup.shで生成されたもの)
-    // ※汎用化のため、topology.txtや環境変数から取るべきだが、今回はハードコードで解決する
-    Name identityName("/ndn/waseda/labA/ndn-node3");
-
-    ndn::security::pib::Identity myIdentity;
-    try {
-        myIdentity = m_keyChain.getPib().getIdentity(identityName);
-    } catch (const std::exception&) {
-        // フルネームがない場合、仕方ないのでデフォルトを使う
-        std::cout << "WARN: Full identity " << identityName << " not found. Using default." << std::endl;
-        myIdentity = m_keyChain.getPib().getDefaultIdentity();
-    }
-
-    std::cout << "Using Identity for Decryptor: " << myIdentity.getName() << std::endl;
-
-    // 4. Decryptorの初期化 (遅延初期化)
-    m_decryptor = std::make_unique<Decryptor>(
-        myIdentity.getDefaultKey(), // KDKに適合する鍵を渡す
-        m_validator,
-        m_keyChain,
-        m_face
-    );
-
-    // 5. KDK配信登録
-    // Decryptorが投げるInterest (Short Name かもしれないし Long かもしれない) を
-    // 確実に拾うために、KDKの完全一致ではなく、前方一致(Prefix)で登録する
-    // .../ENCRYPTED-BY まで登録しておけば、後ろが何であれ拾える
-    Name prefixToServe = m_kdkData->getName().getPrefix(encryptedByIdx + 1); // .../ENCRYPTED-BY
-    std::cout << "Serving KDK at prefix: " << prefixToServe << std::endl;
-
-    m_kdkHandle = m_face.setInterestFilter(
-        prefixToServe,
-        [this](const InterestFilter&, const Interest& interest) {
-            // Decryptorからの要求であれば返す
-            // 名前が完全一致しなくても、KDKを返してみる (Decryptorが判断する)
-             m_face.put(*m_kdkData);
-        },
-        [](const Name&, const std::string& msg) { std::cerr << "KDK Reg Failed: " << msg << std::endl; }
-    );
   }
 
-  void run()
-  {
+  // コンテンツ取得リクエスト
+  void sendContentInterest() {
     Interest interest(m_dataPrefix);
     interest.setCanBePrefix(true);
     interest.setMustBeFresh(true);
@@ -141,13 +156,15 @@ public:
       std::bind(&Consumer::onNack, this, std::placeholders::_1, std::placeholders::_2),
       std::bind(&Consumer::onTimeout, this, std::placeholders::_1)
     );
-
-    m_face.processEvents();
   }
 
-private:
   void onData(const Interest&, const Data& data) {
-    std::cout << "Received Data. Decrypting..." << std::endl;
+    std::cout << "Received Content Data. Decrypting..." << std::endl;
+
+    if (!m_decryptor) {
+        std::cerr << "FATAL: Decryptor not initialized!" << std::endl;
+        exit(1);
+    }
 
     Block contentBlock = data.getContent();
     contentBlock.parse();
@@ -167,20 +184,20 @@ private:
     );
   }
 
-  void onNack(const Interest&, const lp::Nack& nack) const {
-    std::cerr << "Nack: " << nack.getReason() << std::endl;
+  void onNack(const Interest& interest, const lp::Nack& nack) const {
+    std::cerr << "Nack for " << interest.getName() << ": " << nack.getReason() << std::endl;
     exit(1);
   }
 
-  void onTimeout(const Interest&) const {
-    std::cerr << "Timeout" << std::endl;
+  void onTimeout(const Interest& interest) const {
+    std::cerr << "Timeout for " << interest.getName() << std::endl;
     exit(1);
   }
 
   KeyChain m_keyChain;
   Face m_face;
   ValidatorConfig m_validator;
-  std::unique_ptr<Decryptor> m_decryptor; // ポインタに変更
+  std::unique_ptr<Decryptor> m_decryptor;
   std::shared_ptr<Data> m_kdkData;
   ScopedRegisteredPrefixHandle m_kdkHandle;
   Name m_dataPrefix;

--- a/mesh/manifest/apps/kdk-server.cpp
+++ b/mesh/manifest/apps/kdk-server.cpp
@@ -1,0 +1,105 @@
+#include <ndn-cxx/face.hpp>
+#include <ndn-cxx/security/key-chain.hpp>
+#include <ndn-cxx/util/io.hpp>
+#include <iostream>
+#include <filesystem>
+#include <map>
+
+namespace fs = std::filesystem;
+
+namespace ndn::nac::server {
+
+class KdkServer
+{
+public:
+  KdkServer()
+    : m_face(nullptr, m_keyChain)
+  {
+    loadDataFiles("/data/nac-data");
+  }
+
+  void run()
+  {
+    if (m_store.empty()) {
+      std::cerr << "WARN: No data loaded. Server is idle." << std::endl;
+    } else {
+      std::cout << "KDK Server running. Serving " << m_store.size() << " data packets." << std::endl;
+    }
+    m_face.processEvents();
+  }
+
+private:
+  void loadDataFiles(const std::string& pathStr)
+  {
+    fs::path dir(pathStr);
+    if (!fs::exists(dir) || !fs::is_directory(dir)) {
+      std::cerr << "Error: Directory not found: " << pathStr << std::endl;
+      return;
+    }
+
+    for (const auto& entry : fs::directory_iterator(dir)) {
+      if (entry.path().extension() == ".data") {
+        try {
+          auto data = ndn::io::load<Data>(entry.path().string());
+          if (data) {
+            storeData(data);
+          }
+        }
+        catch (const std::exception& e) {
+          std::cerr << "Failed to load " << entry.path() << ": " << e.what() << std::endl;
+        }
+      }
+    }
+  }
+
+  void storeData(std::shared_ptr<Data> data)
+  {
+    Name name = data->getName();
+    m_store[name] = data;
+
+    std::cout << "Loaded: " << name << std::endl;
+
+    // NACのKDKやKEKは、名前が特殊であるため、
+    // ここでは単純化のために「Dataの完全名」でInterestFilterを設定するのではなく、
+    // 「AccessManagerのPrefix」や「KEKのPrefix」を広報するのが正しい。
+    // しかし、動的にPrefixを決定するのが難しいため、
+    // 「Dataの名前そのもの(Full Name without implicit digest)」に対してFilterを設定するアプローチをとる。
+    // ※あるいは、AMのPrefix ("/ndn/AM") が固定なら、コンストラクタで1回だけ登録する方が効率的。
+
+    // 今回は確実にHitさせるため、各データの名前で登録する (データ数が少ない実験環境ならこれでOK)
+    m_face.setInterestFilter(name,
+      [this, data](const InterestFilter&, const Interest& interest) {
+        // InterestがCanBePrefixを持っている場合などに対応
+        if (data->getName().isPrefixOf(interest.getName()) ||
+            interest.matchesData(*data)) {
+          std::cout << "Serving: " << data->getName() << std::endl;
+          m_face.put(*data);
+        }
+      },
+      [](const Name& prefix, const std::string& msg) {
+        std::cerr << "Register failed for " << prefix << ": " << msg << std::endl;
+      }
+    );
+  }
+
+private:
+  KeyChain m_keyChain;
+  Face m_face;
+  // メモリ上にDataを保持する簡易ストア
+  std::map<Name, std::shared_ptr<Data>> m_store;
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  try {
+    ndn::nac::server::KdkServer server;
+    server.run();
+  }
+  catch (const std::exception& e) {
+    std::cerr << "FATAL: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/mesh/manifest/templates/app-src-configmap.yaml
+++ b/mesh/manifest/templates/app-src-configmap.yaml
@@ -11,3 +11,6 @@ data:
 
   nac-utils.hpp: |
     {{- .Files.Get "apps/nac-utils.hpp" | nindent 4 }}
+
+  kdk-server.cpp: |
+    {{- .Files.Get "apps/kdk-server.cpp" | nindent 4 }}

--- a/mesh/manifest/templates/node-manifest.yaml
+++ b/mesh/manifest/templates/node-manifest.yaml
@@ -65,20 +65,6 @@ spec:
               mkdir -p /run/nfd
               mkdir -p /tmp/nlsr
 
-              if ls /data/nac-data/kdk_*.data 1> /dev/null 2>&1; then
-                  echo "=== AM Node Detected (KDK files found) ==="
-                  echo "Compiling KDK Server..."
-                  g++ -o /usr/local/bin/kdk-server /usr/src/app/kdk-server.cpp \
-                      $(pkg-config --cflags --libs libndn-cxx) -std=c++17
-                  if [ $? -eq 0 ]; then
-                      echo "Starting KDK Server in background..."
-                      /usr/local/bin/kdk-server > /data/kdk-server.log 2>&1 &
-                  else
-                      echo "Error: Failed to compile KDK Server"
-                  fi
-              else
-                  echo "=== Consumer/Producer Node (No KDK files) ==="
-              fi
               while true; do sleep 3600; done
 
           volumeMounts:

--- a/mesh/manifest/templates/node-manifest.yaml
+++ b/mesh/manifest/templates/node-manifest.yaml
@@ -64,6 +64,21 @@ spec:
               echo "Pod started. Waiting for activation script..."
               mkdir -p /run/nfd
               mkdir -p /tmp/nlsr
+
+              if ls /data/nac-data/kdk_*.data 1> /dev/null 2>&1; then
+                  echo "=== AM Node Detected (KDK files found) ==="
+                  echo "Compiling KDK Server..."
+                  g++ -o /usr/local/bin/kdk-server /usr/src/app/kdk-server.cpp \
+                      $(pkg-config --cflags --libs libndn-cxx) -std=c++17
+                  if [ $? -eq 0 ]; then
+                      echo "Starting KDK Server in background..."
+                      /usr/local/bin/kdk-server > /data/kdk-server.log 2>&1 &
+                  else
+                      echo "Error: Failed to compile KDK Server"
+                  fi
+              else
+                  echo "=== Consumer/Producer Node (No KDK files) ==="
+              fi
               while true; do sleep 3600; done
 
           volumeMounts:

--- a/mesh/nac-setup/generate_nac_keys.py
+++ b/mesh/nac-setup/generate_nac_keys.py
@@ -118,7 +118,7 @@ def main():
     all_nodes = get_all_nodes()
 
     # 2. 基本IDの生成 (全ノード)
-    org_prefix = config.get('org_prefix', '/ndn/test')
+    org_prefix = config.get('org_prefix', '')
     node_cert_map = generate_base_identities(all_nodes, org_prefix)
 
     # 3. NACポリシーの適用 (AM, KEK, KDK)

--- a/mesh/nac-setup/generate_nac_keys.py
+++ b/mesh/nac-setup/generate_nac_keys.py
@@ -91,13 +91,11 @@ def generate_kek_and_kdk(am_identity, am_dir, content_config, node_cert_map):
             continue
 
         consumer_cert = Path(node_cert_map[consumer])
-        consumer_dir = OUT_DIR / consumer
-        consumer_dir.mkdir(exist_ok=True)
 
-        kdk_filename = f"kdk_{prefix_hash}.data"
-        kdk_path = consumer_dir / kdk_filename
+        kdk_filename = f"kdk_{prefix_hash}_{consumer}.data"
+        kdk_path = am_dir / kdk_filename
 
-        print(f"    > Generating KDK for {consumer}")
+        print(f"    > Generating KDK for {consumer} (Saved in AM dir)")
         run_cmd(f"ndn-nac add-member -i {am_identity} -d {data_prefix} -m {consumer_cert} -o {kdk_path}")
 
 def process_nac_policies(config, node_cert_map):

--- a/mesh/nac-setup/setup.sh
+++ b/mesh/nac-setup/setup.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 WORK_DIR=$(pwd)
 MESH_ROOT=$(dirname "$WORK_DIR")
 OUT_DIR="$WORK_DIR/out"
-IMAGE="icekarinn/nac-generator:v1.2"
+IMAGE="icekarinn/nac-generator:v1.3"
 
 rm -rf "$OUT_DIR"
 


### PR DESCRIPTION
元々kdkがk8s secretによって各podにマウントされる仕組みだったため、consumerでkdkを秘密鍵で復号化する際に、ローカルに与えられたkdkを復号することでcontentを復号取得する仕組みになっていた。
これをkdkはAMノードが持つようにして、consumerはcontentを取得した後、対応するkdkを得るためにkdkをinterestする必要にし、producerノードにおけるkdk-server(create.sh実行によってpodが起動すると同時にバックグラウンドで起動するようにした)によってkdkをdataパケットとして返す仕組みも実装した。